### PR TITLE
sd tute website

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [feature/sd-tute-website]
+    branches: [main]
   workflow_dispatch:
 
 name: Publish to GitHub Pages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+on:
+  push:
+    branches: [feature/sd-tute-website]
+  workflow_dispatch:
+
+name: Publish to GitHub Pages
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          packages: |
+            deSolve
+            tidyverse
+            lubridate
+            purrr
+            janitor
+
+      - uses: quarto-dev/quarto-actions/setup@v2
+
+      - name: Publish to GitHub Pages
+        uses: quarto-dev/quarto-actions/publish@v2
+        with:
+          target: gh-pages
+          path: website-tutorials

--- a/website-tutorials/_quarto.yml
+++ b/website-tutorials/_quarto.yml
@@ -1,0 +1,27 @@
+project:
+  type: website
+  output-dir: _site
+
+website:
+  title: "SD Tutorials"
+  navbar:
+    left:
+      - href: index.qmd
+        text: Home
+      - href: tut-01-first-order-positive-feedback.qmd
+        text: "1: Positive Feedback"
+      - href: tut-02-first-order-positive-feedback-behavior.qmd
+        text: "2: Sensitivity Analysis"
+      - href: tut-03-first-order-negative-feedback.qmd
+        text: "3: Negative Feedback"
+      - href: tut-04-closing-the-gap.qmd
+        text: "4: Closing the Gap"
+      - href: tut-05-s-shaped-growth.qmd
+        text: "5: S-Shaped Growth"
+
+format:
+  html:
+    theme: united
+    toc: true
+    number-sections: false
+    highlight-style: tango

--- a/website-tutorials/index.qmd
+++ b/website-tutorials/index.qmd
@@ -1,0 +1,17 @@
+---
+title: "System Dynamics Tutorials"
+subtitle: "A data science reboot of MIT's Road Maps self-study series"
+author: "Kenneth Moore"
+---
+
+These tutorials replicate examples from the **MIT System Dynamics in Education Project** Road Maps series (supervised by Jay W. Forrester), implemented in R using `deSolve` and `ggplot2`.
+
+## Tutorials
+
+| # | Title | Key concept |
+|---|-------|-------------|
+| [1](tut-01-first-order-positive-feedback.qmd) | First-Order Positive Feedback | Exponential growth |
+| [2](tut-02-first-order-positive-feedback-behavior.qmd) | Behavior of Positive Feedback Systems | Sensitivity analysis |
+| [3](tut-03-first-order-negative-feedback.qmd) | First-Order Negative Feedback | Goal-seeking / exponential decay |
+| [4](tut-04-closing-the-gap.qmd) | Closing the Gap | Asymptotic growth and decay |
+| [5](tut-05-s-shaped-growth.qmd) | S-Shaped Growth | Combined positive and negative feedback |


### PR DESCRIPTION
Closes #1

## Summary
- Adds `website-tutorials/_quarto.yml` to define the Quarto website structure and navbar
- Adds `website-tutorials/index.qmd` as the landing page with a table linking all 5 tutorials
- Adds `.github/workflows/publish.yml` to render and deploy the site to GitHub Pages on push

## Test plan
- [ ] Confirm GitHub Actions workflow runs successfully
- [ ] Verify the site renders at the GitHub Pages URL
- [ ] Check all 5 tutorial links work from the navbar and index table

Generated with [Claude Code](https://claude.ai/claude-code)